### PR TITLE
Implement region-aware dropdown disabling

### DIFF
--- a/src/components/Navbar.jsx
+++ b/src/components/Navbar.jsx
@@ -43,6 +43,7 @@ const Navbar = ({
         setSearchTerm={setSearchTerm}
         searchType={searchType}
         setSearchType={setSearchType}
+        country={country}
       />
       <select
         value={country}
@@ -63,6 +64,7 @@ const Navbar = ({
       <select
         className="bg-dark-100 border border-gray-100 rounded-md py-2 px-2"
         onChange={() => setSearchType('person')}
+        disabled={!country}
       >
         <option>People</option>
         <option>Actors</option>
@@ -75,6 +77,7 @@ const Navbar = ({
         value={movieGenre}
         onChange={(e) => setMovieGenre(e.target.value)}
         className="bg-dark-100 border border-gray-100 rounded-md py-2 px-2"
+        disabled={!country}
       >
         <option value="">Movies</option>
         {movieGenres.map((g) => (
@@ -87,6 +90,7 @@ const Navbar = ({
         value={tvGenre}
         onChange={(e) => setTvGenre(e.target.value)}
         className="bg-dark-100 border border-gray-100 rounded-md py-2 px-2"
+        disabled={!country}
       >
         <option value="">TV Shows</option>
         {tvGenres.map((g) => (

--- a/src/components/Search.jsx
+++ b/src/components/Search.jsx
@@ -1,6 +1,6 @@
 import React from 'react';
 
-const Search = ({ searchTerm, setSearchTerm, searchType, setSearchType }) => {
+const Search = ({ searchTerm, setSearchTerm, searchType, setSearchType, country }) => {
   return (
     <div className="search">
       <div>
@@ -15,6 +15,7 @@ const Search = ({ searchTerm, setSearchTerm, searchType, setSearchType }) => {
           value={searchType}
           onChange={(e) => setSearchType(e.target.value)}
           className="ml-2 bg-dark-100 border border-gray-100 rounded-md text-gray-200 py-2 px-2"
+          disabled={!country}
         >
           <option value="movie">Movie</option>
           <option value="tv">TV</option>


### PR DESCRIPTION
## Summary
- disable People/Movie/TV Show dropdown filters until a country is picked
- propagate country into the search component and disable the search type dropdown when no country is selected

## Testing
- `npm run lint` *(fails: A config object is using the "env" key, which is not supported in flat config system)*

------
https://chatgpt.com/codex/tasks/task_e_6862ba4867548326b1ad322fdd5897ab